### PR TITLE
Modified GCN to work with batched radius graph

### DIFF
--- a/notebooks/knn_approx.ipynb
+++ b/notebooks/knn_approx.ipynb
@@ -450,10 +450,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "id": "f31d7b83-2baf-4083-a89d-facc1faadd00",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(4, 5001, 3)"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "model = GraphWrapper()\n",
     "graph_update, params  = model.init_with_output(rng, graph)\n",


### PR DESCRIPTION
@florpi Two minor changes to the GCN module and message massing scheme to work with the jittable radius graph. Have a look and see if it looks ok! 

Essentially, the jax-md radius graph creates a fixed-size neighbour list (with some slack in size, e.g. a factor of 1.5, so that it can later be updated to accommodate more neighbours). When this is converted to a jraph `GraphTuple`, a dummy graph which contains the extra nodes and edges is added to maintain the fixed sized edge list. So the changes are:

1. Check if receivers are `None` when doing the node update to accommodate the dummy graph with no edges
2. Change how the globals are flattened to account for the dummy graphs (so it's not flattened to `[1, -1]` but `[globals.shape[0], -1]`).

This doesn't yet actually include the radius graph in the diffusion model, but just sets up being able to pass one through the graph.
